### PR TITLE
Adding scaling speed for enemies based on progress difference along s…

### DIFF
--- a/Assets/Scripts/Race/RaceProgressTracker.cs
+++ b/Assets/Scripts/Race/RaceProgressTracker.cs
@@ -6,9 +6,10 @@ public class RaceProgressTracker : MonoBehaviour
 {
     private SplineContainer trackSpline;
     private Transform boat;
-    private float raceProgress = 0f; // 0-100% 
-    public float RaceProgress => raceProgress;
-    //private float lastLoggedProgress = -1f;
+    private float raceDistance = 0f; // Distance traveled along the spline
+
+    public float RaceDistance => raceDistance;
+
     void Start()
     {
         GameObject splineObject = GameObject.Find("raceSpline");
@@ -30,36 +31,22 @@ public class RaceProgressTracker : MonoBehaviour
         boat = transform;
     }
 
-    // part of printing out boat name and progress
     void Update()
     {
-        // Get the spline track
         Spline spline = trackSpline.Splines[0];
 
-        // Convert the boat position to the local space of the spline
         float3 boatLocalPosition = trackSpline.transform.InverseTransformPoint(boat.position);
 
-        // Get nearest point on the spline 
         float3 nearestPoint;
         float t;
-        SplineUtility.GetNearestPoint(spline, boatLocalPosition, out nearestPoint, out t, 100); 
+        SplineUtility.GetNearestPoint(spline, boatLocalPosition, out nearestPoint, out t, 100);
 
-        // Convert nearest point back to world space
         nearestPoint = trackSpline.transform.TransformPoint(nearestPoint);
 
-        // Convert t (0-1) to percentage (0-100%)
-        raceProgress = t * 100f;
+        float splineLength = SplineUtility.CalculateLength(spline, trackSpline.transform.localToWorldMatrix);
 
-        /*
-        // Draw line from boat to nearest point
-        Debug.DrawLine(boat.position, nearestPoint, Color.red, 0.01f);
+        raceDistance = t * splineLength; // Use distance instead of percentage
 
-        // prints out boat name and progress for debugging
-        if (Mathf.Abs(raceProgress - lastLoggedProgress) >= 1f)
-        {
-            Debug.Log($"{boat.name} Progress: {raceProgress}%");
-            lastLoggedProgress = raceProgress; // Update last logged value
-        }
-        */
+        //Debug.DrawLine(boat.position, nearestPoint, Color.red, 0.01f);
     }
 }

--- a/Assets/Scripts/Race/enemyPath.cs
+++ b/Assets/Scripts/Race/enemyPath.cs
@@ -142,20 +142,20 @@ public class enemyPath : MonoBehaviour
         float progressDifference = enemyProgress - playerProgress;
         float absDifference = Mathf.Abs(progressDifference);
 
-        // Only do speed adjustment if the speed difference is greater than 2%
-        if (absDifference > 2f) 
+        // Only do speed adjustment if the speed difference is greater than 20m
+        if (absDifference > 20f) 
         {
             float scaleFactor;
 
-            if (absDifference >= 5f)
+            if (absDifference >= 50f)
             {
-                scaleFactor = 0.8f; 
+                scaleFactor = 0.45f; 
             }          
-            else if (absDifference >= 4f)
+            else if (absDifference >= 40f)
             {
-                scaleFactor = 0.4f;
+                scaleFactor = 0.3f;
             }   
-            else if (absDifference >= 3f)
+            else if (absDifference >= 30f)
              {
                 scaleFactor = 0.2f;
             } else

--- a/Assets/Scripts/Race/enemyPath.cs
+++ b/Assets/Scripts/Race/enemyPath.cs
@@ -132,4 +132,68 @@ public class enemyPath : MonoBehaviour
 
         }
     }
+
+    // Tracks if speed is currently being adjusted
+    private bool isAdjustingSpeed = false; 
+    public bool IsSpeedAdjusted => isAdjustingSpeed; 
+
+    public void AdjustSpeedBasedOnPosition(float playerProgress, float enemyProgress)
+    {
+        float progressDifference = enemyProgress - playerProgress;
+        float absDifference = Mathf.Abs(progressDifference);
+
+        // Only do speed adjustment if the speed difference is greater than 2%
+        if (absDifference > 2f) 
+        {
+            float scaleFactor;
+
+            if (absDifference >= 5f)
+            {
+                scaleFactor = 0.8f; 
+            }          
+            else if (absDifference >= 4f)
+            {
+                scaleFactor = 0.4f;
+            }   
+            else if (absDifference >= 3f)
+             {
+                scaleFactor = 0.2f;
+            } else
+            {
+                scaleFactor = 0.1f;
+            }
+
+            if (progressDifference > 0) // Enemy is ahead so slow down
+            {
+                float targetSpeed = defaultSpeed * (1f - scaleFactor);
+                currentSpeed = Mathf.Lerp(currentSpeed, targetSpeed, Time.deltaTime * 2);
+
+                if (!isAdjustingSpeed)
+                {
+                    isAdjustingSpeed = true;
+                }
+            }
+            else // Enemy is behind so speed up
+            {
+                float targetSpeed = defaultSpeed * (1f + scaleFactor);
+                currentSpeed = Mathf.Lerp(currentSpeed, targetSpeed, Time.deltaTime * 2);
+
+                if (!isAdjustingSpeed)
+                {
+                    isAdjustingSpeed = true;
+                }
+            }
+        }
+    }
+
+    public void ResetSpeed()
+    {
+        if (isAdjustingSpeed) // Only reset if speed was previously changed
+        {
+            Debug.Log(gameObject.name + " has returned to normal speed.");
+            isAdjustingSpeed = false;
+            currentSpeed = defaultSpeed;
+        }
+    }
+
 }

--- a/Assets/Scripts/UI/Placing.cs
+++ b/Assets/Scripts/UI/Placing.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using TMPro;
-using System;
 
 public class Placing : MonoBehaviour
 {
@@ -10,68 +9,60 @@ public class Placing : MonoBehaviour
     private RaceProgressTracker[] boats;
     private TextMeshProUGUI positionText;
 
-
     void Start()
     {
         positionText = GetComponent<TextMeshProUGUI>();
 
         if (positionText == null)
         {
-            Debug.LogError("RaceManager: No TMP found on this GameObject");
+            Debug.LogError("Placing: No TMP found on this GameObject");
             return;
         }
 
-        // Find all the boats by looking for objects with the RaceProgressTracker script
         boats = FindObjectsByType<RaceProgressTracker>(FindObjectsSortMode.None);
     }
 
     void Update()
     {
-
-        // Update progress for each boat
         boatProgress.Clear();
         foreach (var boat in boats)
         {
-            boatProgress[boat] = boat.RaceProgress;
+            boatProgress[boat] = boat.RaceDistance; //  Use distance instead of progress percentage
         }
 
-        // Sort boats by their progress 
         var sortedBoats = boatProgress.OrderByDescending(b => b.Value).ToList();
 
-        // Find the placing of the player boat
         int position = sortedBoats.FindIndex(b => b.Key.gameObject.name == "Boat") + 1;
-
-        // Update the UI text
         positionText.text = GetOrdinal(position);
 
-        // Get player's progress
         RaceProgressTracker playerBoat = boats.FirstOrDefault(b => b.gameObject.name == "Boat");
+        float playerDistance = playerBoat.RaceDistance;
 
-        float playerProgress = playerBoat.RaceProgress;
-
-        // Adjust enemy speeds based on their distance from the player
         foreach (var entry in sortedBoats)
         {
             RaceProgressTracker enemyBoat = entry.Key;
-            if (enemyBoat.gameObject.name == "Boat") continue; // Skip player boat
+            if (enemyBoat.gameObject.name == "Boat") continue;
 
-            float enemyProgress = entry.Value;
-            float progressDifference = Mathf.Abs(enemyProgress - playerProgress);
+            float enemyDistance = entry.Value;
+            float distanceDifference = Mathf.Abs(enemyDistance - playerDistance);
 
-            // Only do speed adjustment if the speed difference is greater than 2%
-            if (progressDifference > 2f) 
+            /*
+            Debug.Log($"{enemyBoat.gameObject.name} is {Mathf.Abs(distanceDifference):F2} meters " +
+                     $"{(distanceDifference > 0 ? "ahead" : "behind")} the player.");
+            */
+            // Only do speed adjustment if the speed difference is greater than 20m
+            if (distanceDifference > 20f)
             {
-                enemyBoat.GetComponent<enemyPath>().AdjustSpeedBasedOnPosition(playerProgress, enemyProgress);
+                enemyBoat.GetComponent<enemyPath>().AdjustSpeedBasedOnPosition(playerDistance, enemyDistance);
             }
             else if (enemyBoat.GetComponent<enemyPath>().IsSpeedAdjusted)
             {
                 Debug.Log("Enemy boat speed has been reset");
-                enemyBoat.GetComponent<enemyPath>().ResetSpeed(); 
+                enemyBoat.GetComponent<enemyPath>().ResetSpeed();
             }
         }
     }
 
-    // Returns the correct format for the placing
     private string GetOrdinal(int number)
     {
         if (number == 1) return number + "st";

--- a/Assets/Scripts/UI/Placing.cs
+++ b/Assets/Scripts/UI/Placing.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using TMPro;
+using System;
 
 public class Placing : MonoBehaviour
 {
@@ -42,6 +43,32 @@ public class Placing : MonoBehaviour
 
         // Update the UI text
         positionText.text = GetOrdinal(position);
+
+        // Get player's progress
+        RaceProgressTracker playerBoat = boats.FirstOrDefault(b => b.gameObject.name == "Boat");
+
+        float playerProgress = playerBoat.RaceProgress;
+
+        // Adjust enemy speeds based on their distance from the player
+        foreach (var entry in sortedBoats)
+        {
+            RaceProgressTracker enemyBoat = entry.Key;
+            if (enemyBoat.gameObject.name == "Boat") continue; // Skip player boat
+
+            float enemyProgress = entry.Value;
+            float progressDifference = Mathf.Abs(enemyProgress - playerProgress);
+
+            // Only do speed adjustment if the speed difference is greater than 2%
+            if (progressDifference > 2f) 
+            {
+                enemyBoat.GetComponent<enemyPath>().AdjustSpeedBasedOnPosition(playerProgress, enemyProgress);
+            }
+            else if (enemyBoat.GetComponent<enemyPath>().IsSpeedAdjusted)
+            {
+                Debug.Log("Enemy boat speed has been reset");
+                enemyBoat.GetComponent<enemyPath>().ResetSpeed(); 
+            }
+        }
     }
 
     // Returns the correct format for the placing


### PR DESCRIPTION
- The speeds of the enemy boats now all scale individually based on the difference in progress along the spline. 
- If the difference is greater than 2%, the speed scales by a multiplier of 0.1, if its greater than 3%, it scales by 0.2, if its greater than 4%, it scales by 0.4, and if its greater than 5%, it scales by 0.8.
- Since ive been testing this on level 14, which is really long, the scale might be a little skewed. It's really easy to adjust so we can fine tune it later
- You wont be able to see the slow down/speed up in the camera view (intentionally cause we wanna keep this hidden from the player), so to see it in action look at the scene view while the race is playing